### PR TITLE
Enable the use of HTML within subtitle

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -140,7 +140,8 @@ ignoreErrors = ["error-remote-getjson"]
           avatarURL = "/images/avatar.png"
           # title shown in home page (HTML format is supported)
           title = ""
-          # subtitle shown in home page (HTML format is supported)
+          # subtitle shown in home page
+          # {{< version 0.1.1 changed >}} (HTML format is supported)
           subtitle = "A Clean, Elegant but Advanced Hugo Theme"
           # whether to use typeit animation for subtitle
           typeit = true

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -140,7 +140,7 @@ ignoreErrors = ["error-remote-getjson"]
           avatarURL = "/images/avatar.png"
           # title shown in home page (HTML format is supported)
           title = ""
-          # subtitle shown in home page
+          # subtitle shown in home page (HTML format is supported)
           subtitle = "A Clean, Elegant but Advanced Hugo Theme"
           # whether to use typeit animation for subtitle
           typeit = true

--- a/exampleSite/content/posts/theme-documentation-basics/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.en.md
@@ -315,6 +315,7 @@ Please open the code block below to view the complete sample configuration :(far
       # title shown in home page (HTML format is supported)
       title = ""
       # subtitle shown in home page
+      # {{< version 0.1.1 changed >}} (HTML format is supported)
       subtitle = "This is My New Hugo Site"
       # whether to use typeit animation for subtitle
       typeit = true

--- a/exampleSite/content/posts/theme-documentation-basics/index.fr.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.fr.md
@@ -320,6 +320,7 @@ Please open the code block below to view the complete sample configuration :(far
       # title shown in home page (HTML format is supported)
       title = ""
       # subtitle shown in home page
+      # {{< version 0.1.1 changed >}} (HTML format is supported)
       subtitle = "This is My New Hugo Site"
       # whether to use typeit animation for subtitle
       typeit = true

--- a/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
@@ -319,6 +319,7 @@ hugo
       title = ""
       # 主页显示的网站副标题
       subtitle = "这是我的全新 Hugo 网站"
+      # {{< version 0.1.1 changed >}} (HTML format is supported)
       # 是否为副标题显示打字机动画
       typeit = true
       # 是否显示社交账号

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -34,7 +34,7 @@
                 <div id="{{ $id }}" class="typeit"></div>
                 {{- dict $id (slice $id) | dict "typeitMap" | merge ($.Scratch.Get "this") | $.Scratch.Set "this" -}}
             {{- else -}}
-                {{- . -}}
+                {{- . | safeHTML -}}
             {{- end -}}
         </h2>
     {{- end -}}


### PR DESCRIPTION
Enables the use of HTML within subtitle.

I wanted to use `<b></b>` and `<br>` inside subtitle but it wasn't working when `typeit = false`. This change make sit possible :)
