### PR TITLE
Rendering author email and name

### DIFF
--- a/layouts/partials/rss/item.html
+++ b/layouts/partials/rss/item.html
@@ -10,7 +10,7 @@
         {{- .Page.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700"  -}}
     </pubDate>
     <author>
-        {{- .params.author | default (T "author") -}}
+      {{ .Site.Author.email }} - ( {{ .Site.Author.name}}  )
     </author>
     <guid>
         {{- .Page.Permalink -}}


### PR DESCRIPTION
<author> Details was not being printed - with       {{ .Site.Author.email }} - ( {{ .Site.Author.name}}  ) the feed validates with w3c against <author> standards.