### PR TITLE
fix(style): gist style improvements

### DIFF
--- a/assets/css/_partial/_single/_code.scss
+++ b/assets/css/_partial/_single/_code.scss
@@ -418,3 +418,21 @@ pre,
     color: $global-font-color-dark !important;
   }
 }
+.markdown-body {
+  background-color: $global-background-color;
+  color: $global-font-color;
+
+  .highlight {
+    background-color: $code-background-color;
+    color: $code-color;
+
+    [theme="dark"] & {
+      background-color: $code-background-color-dark;
+      color: $code-color-dark;
+    }
+  }
+  [theme="dark"] & {
+    background-color: $global-background-color-dark !important;
+    color: $global-font-color-dark !important;
+  }
+}

--- a/assets/css/_partial/_single/_code.scss
+++ b/assets/css/_partial/_single/_code.scss
@@ -54,7 +54,6 @@ pre,
       margin: 0;
       padding: 0;
       border: none !important;
-      white-space: nowrap;
     }
   }
 }
@@ -399,5 +398,23 @@ pre,
     .pl-mdi {
       color: #df6b75;
     }
+  }
+}
+.markdown-body {
+  background-color: $global-background-color;
+  color: $global-font-color;
+
+  .highlight {
+    background-color: $code-background-color;
+    color: $code-color;
+
+    [theme="dark"] & {
+      background-color: $code-background-color-dark;
+      color: $code-color-dark;
+    }
+  }
+  [theme="dark"] & {
+    background-color: $global-background-color-dark !important;
+    color: $global-font-color-dark !important;
   }
 }


### PR DESCRIPTION
fix(style): remove whitespace setting to preserve gist indentation

- The setting white-space: nowrap; strips indentation resulting in poor gist rendering. This removal should resolve that

fix(style): improve gist markdown file rendering

- Background now correctly uses the theme default, allowing render of markdown to be seamless.
- #TODO: Nested code highlights from the markdown file itself still don't render with theming correctly. Could use help on this if it's possible to use the recursion on styles to apply to the gist contents. Not sure.