### PR TITLE
Fix walineJS related questions

### DIFF
--- a/assets/data/cdn/jsdelivr.yml
+++ b/assets/data/cdn/jsdelivr.yml
@@ -66,5 +66,5 @@ libFiles:
   cookieconsentJS: cookieconsent@3.1.1/build/cookieconsent.min.js
   # twikoo@1.4.3 https://github.com/imaegoo/twikoo
   twikooJS: twikoo@1.4.3/dist/twikoo.all.min.js
-  # waline@1.3.3 https://github.com/walinejs/waline
-  walineJS: waline/client@1.3.3/dist/Waline.min.js
+  # waline@1.3.4 https://github.com/walinejs/waline
+  walineJS: '@waline/client@1.3.4/dist/Waline.min.js'

--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -138,6 +138,7 @@
               serverURL: '{{ $waline.serverURL }}',
               visitor: '{{ $waline.visitor }}',
               dark: '{{ $waline.dark }}',
+              requiredMeta: '{{ $waline.requiredFields }}',
             });
             </script>
             <noscript>


### PR DESCRIPTION
- fixed walineJS address (it's missing an `@`)
- added `requiredMeta` for `config.toml` to avoid spam

e.g.
```yaml
# {{< version 0.2.0 >}} {{< link "https://waline.js.org/en/" "Waline" >}} comment config
      [params.page.comment.waline]
        enable = true
        serverURL = "https://xxx.vercel.app/"
        visitor = true
        dark = 'auto'
        requiredFields = ["nick", "mail"] # Use " to avoid errors
```