### PR TITLE
Amend German translation, amend link

### DIFF
--- a/exampleSite/content/posts/theme-documentation-content/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-content/index.en.md
@@ -286,7 +286,7 @@ You can add more block and inline delimiters in your [site configuration](../the
 
 #### Copy-tex
 
-**[Copy-tex](https://github.com/Khan/KaTeX/tree/master/contrib/copy-tex)** is an extension for **$ \KaTeX $**.
+**[Copy-tex](https://github.com/KaTeX/KaTeX/tree/main/contrib/copy-tex)** is an extension for **$ \KaTeX $**.
 
 By the extension, when selecting and copying $ \KaTeX $ rendered elements, copies their $ \LaTeX $ source to the clipboard.
 

--- a/exampleSite/content/posts/theme-documentation-content/index.fr.md
+++ b/exampleSite/content/posts/theme-documentation-content/index.fr.md
@@ -291,7 +291,7 @@ You can add more block and inline delimiters in your [site configuration](../the
 
 #### Copy-tex
 
-**[Copy-tex](https://github.com/Khan/KaTeX/tree/master/contrib/copy-tex)** is an extension for **$ \KaTeX $**.
+**[Copy-tex](https://github.com/KaTeX/KaTeX/tree/main/contrib/copy-tex)** is an extension for **$ \KaTeX $**.
 
 By the extension, when selecting and copying $ \KaTeX $ rendered elements, copies their $ \LaTeX $ source to the clipboard.
 

--- a/exampleSite/content/posts/theme-documentation-content/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-content/index.zh-cn.md
@@ -285,7 +285,7 @@ $ c = \pm\sqrt{a^2 + b^2} $ 和 \\( f(x)=\int\_{-\infty}^{\infty} \hat{f}(\xi) e
 
 #### Copy-tex
 
-**[Copy-tex](https://github.com/Khan/KaTeX/tree/master/contrib/copy-tex)** 是一个 **$ \KaTeX $** 的插件.
+**[Copy-tex](https://github.com/KaTeX/KaTeX/tree/main/contrib/copy-tex)** 是一个 **$ \KaTeX $** 的插件.
 
 通过这个扩展, 在选择并复制 $ \KaTeX $ 渲染的公式时, 会将其 $ \LaTeX $ 源代码复制到剪贴板.
 

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -42,12 +42,12 @@ other = "Mehr"
 other = "Sprache wählen"
 
 [switchTheme]
-other = "Thema wechseln"
+other = "Umschaltung Hell/Dunkel"
 # === partials/header.html ===
 
 # === partials/footer.html ===
 [poweredBySome]
-other = "Ermöglicht durch {{ .Hugo }} | Thema - {{ .Theme }}"
+other = "Ermöglicht durch {{ .Hugo }} | Theme - {{ .Theme }}"
 # === partials/footer.html ===
 
 # === partials/comment.html ===
@@ -87,7 +87,7 @@ other = "lib/lunr/lunr.de.js"
 other = "In Zwischenablage kopieren"
 
 [cookieconsentMessage]
-other = "Diese Website verwendet Cookies, um Ihre Erfahrung zu verbessern."
+other = "Diese Website verwendet Cookies, um Ihren Besuch auf unserer Website optimal zu gestalten."
 
 [cookieconsentDismiss]
 other = "Zustimmen"
@@ -112,15 +112,15 @@ other = "veröffentlicht auf {{ .Date }}"
 other = "enthalten in {{ .Categories }}"
 
 [wordCount]
-one = "Ein wort"
-other = "{{ .Count }} wörter"
+one = "Ein Wort"
+other = "{{ .Count }} Wörter"
 
 [readingTime]
-one = "Eine minute"
-other = "{{ .Count }} minuten"
+one = "Eine Minute"
+other = "{{ .Count }} Minuten"
 
 [views]
-other = "aufrufe"
+other = "Aufrufe"
 
 [author]
 other = "Autor"


### PR DESCRIPTION
* Amended link to `copy-tex`.

* German translation: improved a few phrases, that appear machine translated to me.

One comment: I'm not really happy with

```
[switchTheme]
other = "Switch Theme"
```

I guess


```
other = "Switch light/dark"
```

would be more appropriate, since we are **not** switching the whole theme (IMHO).
I corrected the German translation that way.
